### PR TITLE
Creating order slip - conversion rate fix for multishop with different currencies

### DIFF
--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -266,7 +266,7 @@ class OrderSlipCore extends ObjectModel
 
     public static function create(Order $order, $product_list, $shipping_cost = false, $amount = 0, $amount_choosen = false, $add_tax = true)
     {
-        $currency = new Currency((int)$order->id_currency);
+        $currency = new Currency((int)$order->id_currency, null, (int)$order->id_shop);
         $order_slip = new OrderSlip();
         $order_slip->id_customer = (int)$order->id_customer;
         $order_slip->id_order = (int)$order->id;
@@ -420,7 +420,7 @@ class OrderSlipCore extends ObjectModel
 
     public static function createPartialOrderSlip($order, $amount, $shipping_cost_amount, $order_detail_list)
     {
-        $currency = new Currency($order->id_currency);
+        $currency = new Currency($order->id_currency, null, (int)$order->id_shop);
         $orderSlip = new OrderSlip();
         $orderSlip->id_customer = (int)$order->id_customer;
         $orderSlip->id_order = (int)$order->id;


### PR DESCRIPTION
Conversion rate for order slip is loaded incorrectly in multishop with difference currencies.

How to reproduce:
Create shop A and B.
For A create currency EUR and set conversion_rate to 2.
For B create currency USD and set conversion_rate to 3.
In ps_currency_shop you should have one record for each shop.
Create order slip in shop B (BO context) for order which was created in shop A.
Conversion rate is set to 1, rate is incorrectly loaded from database as null.

