### PR TITLE
Blowfish : handle cases when $plaintext is not countable

### DIFF
--- a/classes/Blowfish.php
+++ b/classes/Blowfish.php
@@ -69,7 +69,7 @@ class BlowfishCore extends Crypt_Blowfish
 
     public function maxi_pad($plaintext)
     {
-        $str_len = count($plaintext);
+        $str_len = is_array($plaintext) ? count($plaintext) : 0;
         $pad_len = $str_len % 8;
         for ($x = 0; $x < $pad_len; $x++) {
             $plaintext = $plaintext.' ';


### PR DESCRIPTION
I can't remember when this happen, but it happens.
I fixed it a long time ago, it was needed.

Sorry, this is obscure but I had this fix in place...
