### PR TITLE
Apply chosen on any admin tab

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -735,7 +735,14 @@ $(document).ready(function()
 	$(document).on('shown.bs.modal', function (e) {
 		$('select.chosen-modal').chosen();
 	})
+        // Apply chosen() when tab is used (refresh width) as explained at https://harvesthq.github.io/chosen/options.html
+        $(document).on('shown.bs.tab', function (e) {
+                $('select.chosen').each(function(k, item){
+                        $(item).chosen("destroy").chosen({disable_search_threshold: 10, search_contains: true});
+                });
+        })
 
+	
 	$('.isInvisible input, .isInvisible select, .isInvisible textarea').attr('disabled', true);
 	$('.isInvisible label.conf_title').addClass('isDisabled');
 


### PR DESCRIPTION
When chosen is applied on hidden element, width is set to 0.
Then to allow this behavior in any admin tab we must destroy them and recreate them.

https://harvesthq.github.io/chosen/options.html

>The width of the Chosen select box. By default, Chosen attempts to match the width of the select box you are replacing. If your select is hidden when Chosen is instantiated, you must specify a width or the select will show up with a width of 0.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | no
| How to test?      | enable chosen on any select manage on tab element  (as module admin and tab use)
| Possible impacts? | any

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
