### PR TITLE
Add a hook 'actionValidateOrderAfter', This hook is called after the …

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -819,6 +819,14 @@ abstract class PaymentModuleCore extends Module
                 PrestaShopLogger::addLog('PaymentModule::validateOrder - End of validateOrder', 1, null, 'Cart', (int)$id_cart, true);
             }
 
+            Hook::exec('actionValidateOrderAfter', [
+                'cart' => $this->context->cart,
+                'order' => $order,
+                'customer' => $this->context->customer,
+                'currency' => $this->context->currency,
+                'orderStatus' => new OrderState($order->current_state),
+            ]);
+
             return true;
         } else {
             $error = Tools::displayError('Cart cannot be loaded or an order has already been placed using this cart');

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -13,6 +13,9 @@
     <hook id="actionValidateOrder" live_edit="0">
       <name>actionValidateOrder</name><title>New orders</title><description/>
     </hook>
+    <hook id="actionValidateOrderAfter">
+      <name>actionValidateOrderAfter</name><title>After validating an order</title><description>This hook is called after validating an order by core</description>
+    </hook>
     <hook id="displayMaintenance" live_edit="0">
       <name>displayMaintenance</name><title>Maintenance Page</title><description>This hook displays new elements on the maintenance page</description>
     </hook>

--- a/install-dev/upgrade/sql/1.6.1.25.sql
+++ b/install-dev/upgrade/sql/1.6.1.25.sql
@@ -1,0 +1,4 @@
+SET NAMES 'utf8';
+
+INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'actionValidateOrderAfter', 'New Order', 'This hook is called after validating an order by core', '1');


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a new hook 'actionValidateOrderAfter', This hook is called after the complete creation of an order
| Type?             | new feature 
| BC breaks?        | no
| Deprecations?     | no
| Possible impacts? | No impact

When an order is created, several modules can be called by the validateOrder hook or other hooks.
There are very often problems and an order is not completely created, no status, no confirmation email sent etc... the reasons can be multiple, poorly developed module, unexpected error, call to an api that does not respond.
Linking PrestaShop to an ERP is more and more common and the exchanges must be reliable.
Also sending to an ERP can generate a change of status for the order but since it is not completely created, there can be conflicts.
This hook allows to create the order completely and then the hook is executed, sending the order to an ERP for example, allows to have the whole order with a status etc. and if the link with the ERP does not work, the order is not "corrupted".
I took the example of liaison with an ERP because I added this hook on several sites and it is very useful.
