### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-This repository has been archived, it’s no longer maintained but you still can fork it if you need it. If you look for a new version of the PrestaShop you can go to [this repository](https://github.com/PrestaShop/PrestaShop).
+### This repository has been archived, it’s no longer maintained but you still can fork it if you need it.
+If you look for a new version of the PrestaShop you can go to [this repository](https://github.com/PrestaShop/PrestaShop).
 
 About PrestaShop
 --------

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This repository has been archived, it’s no longer maintained but you still can fork it if you need it. If you look for a new version of the PrestaShop you can go to [this repository](https://github.com/PrestaShop/PrestaShop).
+
 About PrestaShop
 --------
 


### PR DESCRIPTION
This repository did its job. The community released PrestaShop 1.6 for PHP 7.2 and provided a few security fixes. It's time to let 1.6 live in peace as an archived repository.